### PR TITLE
ロゴサイズを112x28pxにサイズダウン

### DIFF
--- a/static/logo.svg
+++ b/static/logo.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 25.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="レイヤー_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
-	 y="0px" viewBox="0 0 114 33.7" style="enable-background:new 0 0 114 33.7;" xml:space="preserve">
+	 y="0px" height="28" viewBox="0 0 111 28" width="111" style="enable-background:new 0 0 111 28;" xml:space="preserve">
 <style type="text/css">
 	.st0{enable-background:new    ;}
 	.st1{fill:#FFFFFF;}


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #20
- close #27

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- logo.svg のサイズを 111x28 へ変更

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
- android
![Screenshot_2021-01-30-17-42-41-32](https://user-images.githubusercontent.com/13390370/106352279-0bedb680-6325-11eb-943a-5cb600d8ff79.png)
- PC
![logo_pc](https://user-images.githubusercontent.com/13390370/106352290-2f186600-6325-11eb-842f-078da06eed88.png)


