### PR TITLE
OGP Builderワークフローの失敗を修正

### DIFF
--- a/ui-test/ogp_screenshot.py
+++ b/ui-test/ogp_screenshot.py
@@ -8,20 +8,20 @@ if not os.path.exists("ogp"):
 
 PATHS = {
     "/?dummy": (959, 500),
-    "/cards/details-of-confirmed-cases": (959, 500),
+    # "/cards/details-of-confirmed-cases": (959, 500),
     "/cards/number-of-confirmed-cases": (959, 500),
     "/cards/attributes-of-confirmed-cases": (959, 480),
-    "/cards/number-of-tested": (959, 540),
-    "/cards/number-of-reports-to-covid19-telephone-advisory-center": (959, 500),
-    "/cards/number-of-reports-to-covid19-consultation-desk": (959, 500),
-    "/cards/predicted-number-of-toei-subway-passengers": (959, 750),
-    "/cards/agency": (959, 730),
-    "/cards/details-of-tested-cases": (959, 500),
-    "/cards/number-of-inspection-persons": (959, 600),
-    "/cards/shinjuku-visitors": (959, 820),
-    "/cards/chiyoda-visitors": (959, 820),
-    "/cards/shinjuku-st-heatmap": (959, 600),
-    "/cards/tokyo-st-heatmap": (959, 600)
+    # "/cards/number-of-tested": (959, 540),
+    # "/cards/number-of-reports-to-covid19-telephone-advisory-center": (959, 500),
+    # "/cards/number-of-reports-to-covid19-consultation-desk": (959, 500),
+    # "/cards/predicted-number-of-toei-subway-passengers": (959, 750),
+    # "/cards/agency": (959, 730),
+    # "/cards/details-of-tested-cases": (959, 500),
+    # "/cards/number-of-inspection-persons": (959, 600),
+    # "/cards/shinjuku-visitors": (959, 820),
+    # "/cards/chiyoda-visitors": (959, 820),
+    # "/cards/shinjuku-st-heatmap": (959, 600),
+    # "/cards/tokyo-st-heatmap": (959, 600)
 }
 
 options = webdriver.ChromeOptions()


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #28 

## 📝 関連する issue / Related Issues
- https://github.com/aktnk/covid19/issues/67

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- GitHub ActionsのOGP Builderワークフローが失敗するものを修正
- 回避案です
  - OGPの画像を取得するときにタイムアウトエラーが起きてしまう原因が今のところよくわかっていません
  - （存在しないカードへのアクセスをしたときの待ち時間が長くてタイムアウトではないかと思います）
  - 富士市版で必要がない各カードへのパスを無効化してタイムアウトエラー
  - 実際にはGitHub Actions側で動かさないと問題ないかは不明
