### PR TITLE
add data update workflow

### DIFF
--- a/.github/workflows/data_update.yml
+++ b/.github/workflows/data_update.yml
@@ -1,0 +1,104 @@
+name: datajson update
+
+on:
+  workflow_dispatch:
+  schedule:
+  # 毎日20時に実行:GitHub ActionsはUTCなので、日本時間(JSTはUTCの9時間前)の20時->UTCの11時に実行
+    - cron:  '0 11 * * *'
+env:
+  MAIN_BRANCH: master
+  DEVELOPMENT_BRANCH: development
+jobs:
+  data_generate:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout from covid19-gen-datajson-shizuokapref
+        uses: actions/checkout@v2
+        with:
+          repository: hrsano645/covid19-gen-datajson-shizuokapref
+          ref: master
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Generate jsonfiles
+        run: |
+          bash bat.sh 富士市
+          mkdir data_dist
+          cp *.json data_dist/
+      - name: Upload jsonfiles
+        uses: actions/upload-artifact@v1
+        with:
+          name: datajson
+          path: data_dist
+  data_upload_development:
+    needs: data_generate
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout from ${{ env.DEVELOPMENT_BRANCH }} 
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.DEVELOPMENT_BRANCH }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+      - name: Download data
+        uses: actions/download-artifact@v1
+        with:
+          name: datajson
+      - name: Commit files
+        run: |
+          cp -rp datajson/* data/
+          rm -rf datajson
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add data/*
+          git commit -m "Auto Update Data"
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ env.DEVELOPMENT_BRANCH }}
+  data_upload_deploy:
+    needs: data_generate
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout from ${{ env.MAIN_BRANCH }} 
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.MAIN_BRANCH }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+      - name: Download data
+        uses: actions/download-artifact@v1
+        with:
+          name: datajson
+      - name: Commit files
+        run: |
+          cp -rp datajson/* data/
+          rm -rf datajson
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add data/*
+          git commit -m "Auto Update Data"
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ env.MAIN_BRANCH }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - master
+  workflow_run:
+    workflows:
+      - "datajson update"
+    types:
+      - completed
 
 jobs:
   deploy:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - development
+  workflow_run:
+    workflows:
+      - "datajson update"
+    types:
+      - completed
 
 jobs:
   deploy:

--- a/.github/workflows/ogp_builder.yml
+++ b/.github/workflows/ogp_builder.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - master
+  workflow_run:
+    workflows:
+      - "datajson update"
+    types:
+      - completed
 
 jobs:
   build:


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #42 

## 📝 関連する issue / Related Issues
- https://github.com/aktnk/covid19/issues/54
- https://github.com/hiroyuki-ichikawa/covid19/pull/158
- https://github.com/hrsano645/covid19-gen-datajson-shizuokapref/pull/56

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 静岡県側のデータ更新ワークフローを富士市版の対策サイトにも導入します
- 20時の定期更新を実行
- GitHub Actionsが障害などで動作しなかった場合に備えて手動でデータ更新も可能です（workflow_dispatchトリガーを使ってます）
- データ生成スクリプトはmasterブランチを利用
  - このPR作成時現在で、news.jsonの生成も行います。対策サイトにある「最新のお知らせ」にも対応します -> https://github.com/hrsano645/covid19-gen-datajson-shizuokapref/issues/10
  - スクリプトの実行時に地域名指定を行うことで、富士市版のデータ生成を行っています -> https://github.com/hrsano645/covid19-gen-datajson-shizuokapref/pull/56
    - 該当のスクリプト実行箇所: https://github.com/hiroyuki-ichikawa/fujicity_covid19/pull/43/files#diff-1efde5582e21d4c26011e431af354e82b4a894de45bdd138dd8352bbec869833R41
